### PR TITLE
Fix RelayMsgOption handling

### DIFF
--- a/options.go
+++ b/options.go
@@ -651,7 +651,7 @@ func (o *UnicastOption) UnmarshalBinary(data []byte) error {
 
 // Status Code Option
 type StatusCodeOption struct {
-	StatusCode    byte
+	StatusCode    uint16
 	StatusMessage string
 }
 
@@ -663,15 +663,15 @@ func (o *StatusCodeOption) MarshalBinary() ([]byte, error) {
 	if len(msgData) > 65534 {
 		return nil, ErrWontFit
 	}
-	data := make([]byte, 5+len(msgData))
+	data := make([]byte, 6+len(msgData))
 	binary.BigEndian.PutUint16(data, uint16(OptionCodeStatusCode))
-	binary.BigEndian.PutUint16(data[2:], uint16(len(msgData)+1))
-	data[4] = o.StatusCode
-	copy(data[5:], msgData)
+	binary.BigEndian.PutUint16(data[2:], uint16(len(msgData)+2))
+	binary.BigEndian.PutUint16(data[4:], o.StatusCode)
+	copy(data[6:], msgData)
 	return data, nil
 }
 func (o *StatusCodeOption) UnmarshalBinary(data []byte) error {
-	if len(data) < 5 {
+	if len(data) < 6 {
 		return ErrUnexpectedEOF
 	}
 	if binary.BigEndian.Uint16(data) != uint16(OptionCodeStatusCode) {
@@ -681,8 +681,8 @@ func (o *StatusCodeOption) UnmarshalBinary(data []byte) error {
 	if len(data) < int(olen)+4 {
 		return ErrUnexpectedEOF
 	}
-	o.StatusCode = data[4]
-	o.StatusMessage = string(data[5 : olen+4])
+	o.StatusCode = binary.BigEndian.Uint16(data[4:])
+	o.StatusMessage = string(data[6 : olen+4])
 	return nil
 }
 

--- a/options.go
+++ b/options.go
@@ -533,9 +533,8 @@ func (o *ElapsedTimeOption) UnmarshalBinary(data []byte) error {
 }
 
 // Relay Message Option
-// TODO: this
 type RelayMsgOption struct {
-	DhcpRelayMessage DhcpRelayMessage
+	DhcpRelayMessage DhcpMessage
 }
 
 func (o *RelayMsgOption) Code() OptionCode {


### PR DESCRIPTION
Using DhcpRelayMessage instead of DhcpMessage causes unexpected EOF.

kmeaw@kmeaw 20:02:05 /tmp/dhcp6

> >  gore $'import "github.com/mastercactapus/dhcpv6"\nfmt.Println((&dhcpv6.DhcpRelayMessage{}).UnmarshalBinary([]byte{12,0,42,2,6,184,240,32,1,1,0,0,0,0,0,0,0,1,254,128,0,0,0,0,0,0,2,37,144,255,254,229,189,192,0,9,0,114,5,124,18,130,0,1,0,14,0,1,0,1,28,230,124,239,0,37,144,229,189,192,0,2,0,14,0,1,0,1,85,90,10,14,0,37,144,53,195,190,0,39,0,20,98,115,112,115,116,97,116,48,55,105,46,121,97,110,100,101,120,46,114,117,0,8,0,2,55,228,0,3,0,40,144,229,189,192,0,0,14,16,0,0,21,24,0,5,0,24,42,2,6,184,240,32,1,1,2,37,144,255,254,229,189,192,0,0,28,32,0,0,29,76}))'                                   ---------------------------------
> > unexpected EOF

kmeaw@kmeaw 20:02:11 /tmp/dhcp6

> >  gore $'import "./dhcpv6"\nfmt.Println((&dhcpv6.DhcpRelayMessage{}).UnmarshalBinary([]byte{12,0,42,2,6,184,240,32,1,1,0,0,0,0,0,0,0,1,254,128,0,0,0,0,0,0,2,37,144,255,254,229,189,192,0,9,0,114,5,124,18,130,0,1,0,14,0,1,0,1,28,230,124,239,0,37,144,229,189,192,0,2,0,14,0,1,0,1,85,90,10,14,0,37,144,53,195,190,0,39,0,20,98,115,112,115,116,97,116,48,55,105,46,121,97,110,100,101,120,46,114,117,0,8,0,2,55,228,0,3,0,40,144,229,189,192,0,0,14,16,0,0,21,24,0,5,0,24,42,2,6,184,240,32,1,1,2,37,144,255,254,229,189,192,0,0,28,32,0,0,29,76}))'                                                           ---------------------------------
> > <nil>
